### PR TITLE
Fixed link to old session page in the trifecta partial

### DIFF
--- a/source/shared/_trifecta.html.haml
+++ b/source/shared/_trifecta.html.haml
@@ -7,7 +7,7 @@
         and make friends that last a lifetime.
       %ul
         %li= link_to "Camper Care", "/parents/camper-care.html"
-        %li= link_to "Sessions & Tuition", "/parents/sessions-tuitions-2014.html"
+        %li= link_to "Sessions & Tuition", "/parents/sessions-tuitions-2015.html"
         %li= link_to "Why WLC?", "/parents/why-wlc.html"
         %li= link_to "Forms", "/parents/forms.html"
 


### PR DESCRIPTION
Link fix in partial used on homepage
Should we convert the naming convention to not include the year in that page?
